### PR TITLE
fix: signatures are now verifiable

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -8,9 +8,16 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
-       matrix:
-         exist-version: [release, latest]
+      fail-fast: true
+      matrix:
+        exist-version: [release, 6.0.1]
+        experimental: [false]
+        # latest might contain breaking changes
+        include:
+          - exist-version: latest
+            experimental: true
     services:
       # Label used to access the service container
       exist:

--- a/src/content/jwt.xqm
+++ b/src/content/jwt.xqm
@@ -84,8 +84,13 @@ declare function jwt:read ($token as xs:string, $secret as xs:string, $lifetime 
 };
 
 declare function jwt:sign ($data as xs:string, $secret as xs:string) as xs:string {
+    (:
+     : This is a band-aid for the output of crypto:hmac being cast to a base64 encoded xs:string
+     : which uses + and / characters. Since util:base64-encode-url-safe cannot operate on binary data,
+     : we do a manual replacement here.
+     :)
     crypto:hmac($data, $secret, "HMAC-SHA-256", "base64")
-    => util:base64-encode-url-safe()
+    => translate("+/=", "-_") 
 };
 
 (:~

--- a/src/content/jwt.xqm
+++ b/src/content/jwt.xqm
@@ -121,7 +121,7 @@ declare function jwt:epoch-to-dateTime($ts as xs:integer) as xs:dateTime {
 declare
 function jwt:encode ($data as item()) as xs:string {
     util:base64-encode-url-safe(
-        serialize($data, map { "method": "json" }))
+        serialize($data, map { "method": "json", "indent": false() }))
 };
 
 declare


### PR DESCRIPTION
The return of crypto:hmac#4 cannot be passed to util:base64-encode-url-safe() as that will double-encode the base64 encoded value. A simple translate operation will turn the base64 encoded value into a url-safe one that is suitable for use here.

As a result JWTs are now externally verifiable by other tools as jwt.io's token debugger.