### PR TITLE
Update crypto dependency to exist-crypto

### DIFF
--- a/src/expath-pkg.xml.tmpl
+++ b/src/expath-pkg.xml.tmpl
@@ -4,7 +4,7 @@
   abbrev="@package.target@" version="@package.version@" spec="1.0">
   <title>@package.title@</title>
   <dependency processor="http://exist-db.org" semver-min="5.3.0"/>
-  <dependency package="http://expath.org/ns/crypto" semver-min="6.0.0"/>
+  <dependency package="http://exist-db.org/ns/crypto" semver-min="0.9.0"/>
   <xquery>
     <namespace>@package.namespace@</namespace>
     <file>@package.export@</file>


### PR DESCRIPTION
## Summary

- Update `expath-pkg.xml` dependency from `http://expath.org/ns/crypto` (old [expath-crypto-module](https://github.com/eXist-db/expath-crypto-module)) to `http://exist-db.org/ns/crypto` (new [exist-crypto](https://github.com/joewiz/exist-crypto))

## Why

The JWT module depends on the EXPath Crypto Module for `crypto:hmac()`. The old package (`http://expath.org/ns/crypto`) hasn't been tested with eXist-db 7.0. The new [exist-crypto](https://github.com/joewiz/exist-crypto) module provides the same XQuery function namespace (`http://expath.org/ns/crypto`) and the same `crypto:hmac()` function, but with a different EXPath package URI.

The XQuery import in `jwt.xqm` is unchanged — only the package dependency declaration in `expath-pkg.xml` changes.

## New package

The exist-crypto XAR can be downloaded from:
https://github.com/joewiz/exist-crypto/releases

[This response was co-authored with Claude Code. -Joe]

🤖 Generated with [Claude Code](https://claude.com/claude-code)