### PR TITLE
ci: target only latest in test matrix for eXist-db 7 compatibility

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -12,12 +12,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        exist-version: [release, 6.0.1, 5.3.0]
+        # exist-jwt 2.x requires eXist-db 7.0.0-SNAPSHOT or newer (see PR #17),
+        # so the matrix only targets the latest image until eXist-db 7 is released.
+        exist-version: [latest]
         experimental: [false]
-        # latest might contain breaking changes
-        include:
-          - exist-version: latest
-            experimental: true
     services:
       # Label used to access the service container
       exist:


### PR DESCRIPTION
## Summary
- Drops `release`, `6.0.1`, and `5.3.0` from the Semantic Release test matrix and promotes `latest` to the sole (non-experimental) target.
- exist-jwt 2.x now requires eXist-db `7.0.0-SNAPSHOT` (set by #17), so the older matrix entries fail at XAR install with `experr:EXPATH00 Package requires eXist-db version > 7.0.0-SNAPSHOT`. This blocked the Semantic Release run on the #17 merge commit and is preventing the next release from being cut.
- Once eXist-db 7 ships a stable image, the matrix can be expanded again to pin to it alongside `latest`.

## Context
Per Juri's checklist in eXist-db Slack #exist-db-7 ([thread](https://exist-db.slack.com/archives/C0824H3C76J/p1779968354482129)), crypto 7.0.0 is released and #17 is merged; releasing exist-jwt and re-running the roaster tests are the remaining steps. The release CI needs this matrix fix first.

## Test plan
- [ ] Semantic Release workflow on this PR passes the `build (latest, false)` job.
- [ ] After merge to `main`, the Semantic Release job runs and cuts the next exist-jwt version (semantic-release derives the version from commit history since `v2.0.1`).

[This response was co-authored with Claude Code. -Joe]

🤖 Generated with [Claude Code](https://claude.com/claude-code)